### PR TITLE
fix: Fixes Issue #123 allowing scrolling through large list of accounts loaded from Polkadot.js Extension

### DIFF
--- a/src/components/modal/WalletModal.tsx
+++ b/src/components/modal/WalletModal.tsx
@@ -10,8 +10,12 @@ export const WalletModal: FC<WalletModalProps> = ({ isOpen, onClose, children })
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center z-50">
-      <div className="absolute inset-0 bg-black opacity-50" onClick={onClose}></div>
+    <div className="fixed inset-0 flex items-start justify-center z-50 overflow-scroll">
+      <div
+        className="absolute inset-0 bg-black opacity-50"
+        style={{ height: '1000vh' }}
+        onClick={onClose}
+      ></div>
       <div className="relative w-96 bg-white p-6 rounded shadow-lg">
         <button className="absolute top-3 right-3" onClick={onClose}>
           X

--- a/src/components/web3/ConnectButton.tsx
+++ b/src/components/web3/ConnectButton.tsx
@@ -59,125 +59,129 @@ export const ConnectButton: FC<ConnectButtonProps> = () => {
       {!activeAccount && (
         // Connect Button + Modal
         <div className="relative">
-          <button
-            className=" font-unbounded uppercase font-black rounded-2xl hover:bg-pink-3 border border-gray-8 text-xs inline-flex items-center justify-center px-12 py-3 mr-3 text-center text-black hover:bg-primary-800 focus:ring-4 focus:ring-primary-300"
-            onClick={() => setOpenConnect(!openConnect)}
-          >
-            <span>Connect Wallet</span>
-          </button>
+          <div className="absolute top-0">
+            <button
+              className=" font-unbounded uppercase font-black rounded-2xl hover:bg-pink-3 border border-gray-8 text-xs inline-flex items-center justify-center px-12 py-3 mr-3 text-center text-black hover:bg-primary-800 focus:ring-4 focus:ring-primary-300"
+              onClick={() => setOpenConnect(!openConnect)}
+            >
+              <span>Connect Wallet</span>
+            </button>
 
-          <WalletModal isOpen={openConnect} onClose={() => setOpenConnect(false)}>
-            <ul className="rounded-2xl border border-gray-9 bg-white divide-y divide-gray-2">
-              {/* Installed Wallets */}
-              {!isSSR &&
-                !activeAccount &&
-                browserWallets.map((w) =>
-                  isWalletInstalled(w) ? (
-                    <li
-                      key={w.id}
-                      onClick={() => {
-                        // If the wallet has only one account, connect directly.
-                        console.log('w:', w)
-                        connect?.(undefined, undefined, w)
-                        setChosenWallet(w)
-                      }}
-                      className="p-3 flex flex-row cursor-pointer hover:bg-gray-1 transition duration-300"
-                    >
-                      <Image
-                        src={mappingTitletoImg(w.id)}
-                        alt={w.name}
-                        width={24}
-                        height={24}
-                        className="w-6 h-6 mr-2 inline-block"
-                      />
-                      {w.name}
-                    </li>
-                  ) : (
-                    <li key={w.id} className="p-3">
-                      <Link
-                        href={w.urls.website}
-                        className="flex items-center justify-between opacity-50 hover:opacity-70 hover:no-underline transition duration-300"
+            <WalletModal isOpen={openConnect} onClose={() => setOpenConnect(false)}>
+              <ul className="rounded-2xl border border-gray-9 bg-white divide-y divide-gray-2">
+                {/* Installed Wallets */}
+                {!isSSR &&
+                  !activeAccount &&
+                  browserWallets.map((w) =>
+                    isWalletInstalled(w) ? (
+                      <li
+                        key={w.id}
+                        onClick={() => {
+                          // If the wallet has only one account, connect directly.
+                          console.log('w:', w)
+                          connect?.(undefined, undefined, w)
+                          setChosenWallet(w)
+                        }}
+                        className="p-3 flex flex-row cursor-pointer hover:bg-gray-1 transition duration-300"
                       >
-                        <div>
-                          <span>{w.id}</span>
-                          <p className="text-xs mt-1">Not installed</p>
-                        </div>
-                        <FiExternalLink size={16} />
-                      </Link>
-                    </li>
-                  ),
-                )}
-            </ul>
-          </WalletModal>
+                        <Image
+                          src={mappingTitletoImg(w.id)}
+                          alt={w.name}
+                          width={24}
+                          height={24}
+                          className="w-6 h-6 mr-2 inline-block"
+                        />
+                        {w.name}
+                      </li>
+                    ) : (
+                      <li key={w.id} className="p-3">
+                        <Link
+                          href={w.urls.website}
+                          className="flex items-center justify-between opacity-50 hover:opacity-70 hover:no-underline transition duration-300"
+                        >
+                          <div>
+                            <span>{w.id}</span>
+                            <p className="text-xs mt-1">Not installed</p>
+                          </div>
+                          <FiExternalLink size={16} />
+                        </Link>
+                      </li>
+                    ),
+                  )}
+              </ul>
+            </WalletModal>
+          </div>
         </div>
       )}
       {!!activeAccount && (
         // Account Menu & Disconnect Button
-        <div className="">
-          <div className="flex items-center space-x-4">
-            {/* Account Name, Address, and AZNS-Domain (if assigned) */}
-            <button
-              className=" font-unbounded uppercase font-black rounded-2xl hover:bg-pink-3 border border-gray-9 text-xs inline-flex items-center justify-center px-7 py-2 mr-3 text-center text-black focus:ring-4"
-              onClick={() => setOpenChooseAccount(true)}
-            >
-              <div className=" px-6">
-                <AccountName account={activeAccount} />
-                <p className="text-xs font-mono font-thin opafcity-75">
-                  {truncateHash(
-                    encodeAddress(activeAccount.address, activeChain?.ss58Prefix || 42),
-                    8,
-                  )}
-                </p>
-              </div>
-            </button>
-          </div>
-
-          {/* Available Accounts/Wallets */}
-          <WalletModal isOpen={openChooseAccount} onClose={() => setOpenChooseAccount(false)}>
-            <>
-              {chosenWallet &&
-                (accounts || []).map((acc) => {
-                  const encodedAddress = encodeAddress(acc.address, activeChain?.ss58Prefix || 42)
-                  const truncatedEncodedAddress = truncateHash(encodedAddress, 10)
-                  return (
-                    <div
-                      key={encodedAddress}
-                      // When an account is clicked, set it as active and then connect to the chosen wallet.
-                      onClick={() => {
-                        setActiveAccount?.(acc)
-                        connect?.(undefined, undefined, chosenWallet)
-                        if (acc.address !== activeAccount.address) {
-                          setActiveAccount?.(acc)
-                        }
-                      }}
-                      className={`p-3 flex justify-between items-center cursor-pointer ${acc.address === activeAccount.address ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-2'}`}
-                    >
-                      <div>
-                        <AccountName account={acc} />
-                        <p className="text-xs">{truncatedEncodedAddress}</p>
-                      </div>
-                      {acc.address === activeAccount.address && (
-                        <AiOutlineCheckCircle size={16} className="text-green-500" />
-                      )}
-                    </div>
-                  )
-                })}
-
-              {/* Account Balance */}
-              {balanceFormatted !== undefined && (
-                <div className="rounded-2x px-4 py-2 font-bold text-gray-19 hover:bg-gray-9">
-                  {balanceFormatted}
-                </div>
-              )}
-              <div
-                className="p-2 flex justify-between items-center cursor-pointer hover:bg-red-1"
-                onClick={() => disconnect?.()}
+        <div className="relative">
+          <div className="">
+            <div className="flex items-center space-x-4">
+              {/* Account Name, Address, and AZNS-Domain (if assigned) */}
+              <button
+                className=" font-unbounded uppercase font-black rounded-2xl hover:bg-pink-3 border border-gray-9 text-xs inline-flex items-center justify-center px-7 py-2 mr-3 text-center text-black focus:ring-4"
+                onClick={() => setOpenChooseAccount(true)}
               >
-                <span className="text-red-5">Disconnect</span>
-                <AiOutlineDisconnect size={18} className="text-red-5" />
-              </div>
-            </>
-          </WalletModal>
+                <div className=" px-6">
+                  <AccountName account={activeAccount} />
+                  <p className="text-xs font-mono font-thin opafcity-75">
+                    {truncateHash(
+                      encodeAddress(activeAccount.address, activeChain?.ss58Prefix || 42),
+                      8,
+                    )}
+                  </p>
+                </div>
+              </button>
+            </div>
+
+            {/* Available Accounts/Wallets */}
+            <WalletModal isOpen={openChooseAccount} onClose={() => setOpenChooseAccount(false)}>
+              <>
+                {chosenWallet &&
+                  (accounts || []).map((acc) => {
+                    const encodedAddress = encodeAddress(acc.address, activeChain?.ss58Prefix || 42)
+                    const truncatedEncodedAddress = truncateHash(encodedAddress, 10)
+                    return (
+                      <div
+                        key={encodedAddress}
+                        // When an account is clicked, set it as active and then connect to the chosen wallet.
+                        onClick={() => {
+                          setActiveAccount?.(acc)
+                          connect?.(undefined, undefined, chosenWallet)
+                          if (acc.address !== activeAccount.address) {
+                            setActiveAccount?.(acc)
+                          }
+                        }}
+                        className={`p-3 flex justify-between items-center cursor-pointer ${acc.address === activeAccount.address ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-2'}`}
+                      >
+                        <div>
+                          <AccountName account={acc} />
+                          <p className="text-xs">{truncatedEncodedAddress}</p>
+                        </div>
+                        {acc.address === activeAccount.address && (
+                          <AiOutlineCheckCircle size={16} className="text-green-500" />
+                        )}
+                      </div>
+                    )
+                  })}
+
+                {/* Account Balance */}
+                {balanceFormatted !== undefined && (
+                  <div className="rounded-2x px-4 py-2 font-bold text-gray-19 hover:bg-gray-9">
+                    {balanceFormatted}
+                  </div>
+                )}
+                <div
+                  className="p-2 flex justify-between items-center cursor-pointer hover:bg-red-1"
+                  onClick={() => disconnect?.()}
+                >
+                  <span className="text-red-5">Disconnect</span>
+                  <AiOutlineDisconnect size={18} className="text-red-5" />
+                </div>
+              </>
+            </WalletModal>
+          </div>
         </div>
       )}
     </>


### PR DESCRIPTION
* Note: I used `1000vh` since that was necessary for the opacity-50 background to extend down far enough to reach the last account, where there were about ~100 accounts. Otherwise to close the modal you have to scroll up to where the opacity-50 background is visible at the top before you can click outside the modal for it to close.
  * Ideally it should extend all the way to the last account regardless of how many accounts there are.

* Note: Please check that the "Connect Wallet" button is in the right position and that my changes haven't caused it to have moved out of visibility to the right somehow.