### PR TITLE
Update ParaSpell to v6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@material-tailwind/react": "^1.4.2",
     "@mui/material": "^5.16.7",
     "@mui/x-date-pickers": "^6.20.2",
-    "@paraspell/sdk": "^6.0.0",
+    "@paraspell/sdk": "^6.1.1",
     "@polkadot/api-base": "^11.3.1",
     "@poppyseed/squid-sdk": "^0.2.4",
     "@reduxjs/toolkit": "^2.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^6.20.2
         version: 6.20.2(@emotion/react@11.13.3(@types/react@18.2.25)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.2.25)(react@18.3.1))(@types/react@18.2.25)(react@18.3.1))(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.2.25)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.2.25)(react@18.3.1))(@types/react@18.2.25)(react@18.3.1))(@types/react@18.2.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.16.7(@emotion/react@11.13.3(@types/react@18.2.25)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.2.25)(react@18.3.1))(@types/react@18.2.25)(react@18.3.1))(@types/react@18.2.25)(react@18.3.1))(@types/react@18.2.25)(date-fns@3.6.0)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@paraspell/sdk':
-        specifier: ^6.0.0
-        version: 6.0.0(@polkadot/api-base@11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/api@11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/apps-config@0.143.2(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@6.0.3))(@polkadot/types@11.3.1)(@polkadot/util@12.6.2)(bufferutil@4.0.8)(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@6.0.3)
+        specifier: ^6.1.1
+        version: 6.1.1(@polkadot/api-base@11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/api@11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/apps-config@0.143.2(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@6.0.3))(@polkadot/types@11.3.1)(@polkadot/util@12.6.2)(bufferutil@4.0.8)(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@6.0.3)
       '@polkadot/api-base':
         specifier: ^11.3.1
         version: 11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -1121,13 +1121,13 @@ packages:
   '@parallel-finance/type-definitions@2.0.1':
     resolution: {integrity: sha512-fC1QfhFFd8oSZqdIh6kmoMNvTxZdQGw1sTAbdYSINyVxyCxKiDg47ZP9bAZFDexL7POqnXnn4pYM7kUAnsT+8Q==}
 
-  '@paraspell/sdk@6.0.0':
-    resolution: {integrity: sha512-eLK7FFBto+NWzeIfhMwy1rhvhEWx0Qjq7e0iv4GzY/9aVIDGlLEj6GUxTQBmY519jZJJqlYHjBD+H5mlWmDJgw==}
+  '@paraspell/sdk@6.1.1':
+    resolution: {integrity: sha512-IeVnR8klISOIDQxpb/PoSLVzPeLiGWOEt7kMIsdOfTCjaDF+P3NFFe32hPANVFXZn+n5vfdkRbCl+XQLiIs03g==}
     peerDependencies:
-      '@polkadot/api': '>= 12.4'
-      '@polkadot/api-base': '>= 12.4'
-      '@polkadot/apps-config': '>= 0.143'
-      '@polkadot/types': '>= 12.4'
+      '@polkadot/api': '>= 12.4 < 13'
+      '@polkadot/api-base': '>= 12.4 < 13'
+      '@polkadot/apps-config': '>= 0.144'
+      '@polkadot/types': '>= 12.4 < 13'
       '@polkadot/util': '>= 13'
 
   '@peaqnetwork/type-definitions@0.0.4':
@@ -1222,8 +1222,8 @@ packages:
     resolution: {integrity: sha512-BkG2tQpUUO0iUm65nSqP8hwHkNfN8jQw8apqflJNt9H8EkEL6v7sqwbLvGqtlxM9wzdxbg7lrWp3oHg4rOP31g==}
     engines: {node: '>=18'}
 
-  '@polkadot/api-augment@13.1.1':
-    resolution: {integrity: sha512-QWqw2zWpEEyP2s220b6rv0iq44XwhqQabicpGzCeMPAEJOnvzGjZMVD95o2C3oOq1FR025wQ1CU+4la2P4djNw==}
+  '@polkadot/api-augment@13.2.1':
+    resolution: {integrity: sha512-NTkI+/Hm48eWc/4Ojh/5elxnjnow5ptXK97IZdkWAe7mWi9hJR05Uq5lGt/T/57E9LSRWEuYje8cIDS3jbbAAw==}
     engines: {node: '>=18'}
 
   '@polkadot/api-augment@7.15.1':
@@ -1246,8 +1246,8 @@ packages:
     resolution: {integrity: sha512-XYI7Po8i6C4lYZah7Xo0v7zOAawBUfkmtx0YxsLY/665Sup8oqzEj666xtV9qjBzR9coNhQonIFOn+9fh27Ncw==}
     engines: {node: '>=18'}
 
-  '@polkadot/api-base@13.1.1':
-    resolution: {integrity: sha512-VEIOit6oTkOUi3CRUD1c6b/QF3cP0J1XxyMJR5q1/58fgTeUBjREmIyDgZzoXNX5ZK/9VD6pzqoWnKMeJGV5dA==}
+  '@polkadot/api-base@13.2.1':
+    resolution: {integrity: sha512-00twdIjTjzdYNdU19i2YKLoWBmf2Yr6b3qrvqIVScHipUkKMbfFBgoPRB5FtcviBbEvLurgfyzHklwnrbWo8GQ==}
     engines: {node: '>=18'}
 
   '@polkadot/api-base@7.15.1':
@@ -1274,8 +1274,8 @@ packages:
     resolution: {integrity: sha512-R0AMANEnqs5AiTaiQX2FXCxUlOibeDSgqlkyG1/0KDsdr6PO/l3dJOgEO+grgAwh4hdqzk4I9uQpdKxG83f2Gw==}
     engines: {node: '>=18'}
 
-  '@polkadot/api-derive@13.1.1':
-    resolution: {integrity: sha512-Avj4iSZlXXAPEhwnVAA0ZczW1HsgYYIpJFeC6Em3FhpDl4GLxS/UqwpGRhr97Ibqj6Ukv0dJ755xljyXkXiP+A==}
+  '@polkadot/api-derive@13.2.1':
+    resolution: {integrity: sha512-npxvS0kYcSFqmYv2G8QKWAJwFhIv/MBuGU0bV7cGP9K1A3j2Do3yYjvN1dTtY20jBavWNwmWFdXBV6/TRRsgmg==}
     engines: {node: '>=18'}
 
   '@polkadot/api-derive@7.15.1':
@@ -1298,8 +1298,8 @@ packages:
     resolution: {integrity: sha512-e1KS048471iBWZU10TJNEYOZqLO+8h8ajmVqpaIBOVkamN7tmacBxmHgq0+IA8VrGxjxtYNa1xF5Sqrg76uBEg==}
     engines: {node: '>=18'}
 
-  '@polkadot/api@13.1.1':
-    resolution: {integrity: sha512-s4BTMKcf/3YoU14C0GmRC9APQTilNR/kNprRrfP1S+6umwsNoSuFXSZhaUWUovVlNWw7v7dca8NbFDSTjkoS4w==}
+  '@polkadot/api@13.2.1':
+    resolution: {integrity: sha512-QvgKD3/q6KIU3ZuNYFJUNc6B8bGBoqeMF+iaPxJn3Twhh4iVD5XIymD5fVszSqiL1uPXMhzcWecjwE8rDidBoQ==}
     engines: {node: '>=18'}
 
   '@polkadot/api@7.15.1':
@@ -1358,13 +1358,6 @@ packages:
       '@polkadot/util': 12.6.2
       '@polkadot/util-crypto': 12.6.2
 
-  '@polkadot/keyring@13.0.2':
-    resolution: {integrity: sha512-NeLbhyKDT5W8LI9seWTZGePxNTOVpDhv2018HSrEDwJq9Ie0C4TZhUf3KNERCkSveuThXjfQJMs+1CF33ZXPWw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2
-
   '@polkadot/keyring@13.1.1':
     resolution: {integrity: sha512-Wm+9gn946GIPjGzvueObLGBBS9s541HE6mvKdWGEmPFMzH93ESN931RZlOd67my5MWryiSP05h5SHTp7bSaQTA==}
     engines: {node: '>=18'}
@@ -1405,10 +1398,6 @@ packages:
     resolution: {integrity: sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==}
     engines: {node: '>=18'}
 
-  '@polkadot/networks@13.0.2':
-    resolution: {integrity: sha512-ABAL+vug/gIwkdFEzeh87JoJd0YKrxSYg/HjUrZ+Zis2ucxQEKpvtCpJ34ku+YrjacBfVqIAkkwd3ZdIPGq9aQ==}
-    engines: {node: '>=18'}
-
   '@polkadot/networks@13.1.1':
     resolution: {integrity: sha512-eEQ4+Mfl1xFtApeU5PdXZ2XBhxNSvUz9yW+YQVGUCkXRjWFbqNRsTOYWGd9uFbiAOXiiiXbtqfZpxSDzIm4XOg==}
     engines: {node: '>=18'}
@@ -1444,8 +1433,8 @@ packages:
     resolution: {integrity: sha512-IEco5pnso+fYkZNMlMAN5i4XAxdXPv0PZ0HNuWlCwF/MmRvWl8pq5JFtY1FiByHEbeuHwMIUhHM5SDKQ85q9Hg==}
     engines: {node: '>=18'}
 
-  '@polkadot/rpc-augment@13.1.1':
-    resolution: {integrity: sha512-RXcYT+pPkwmAPTpH7DcIjaVEOEzdkAXJBjfF0OxbFKWcqJb8uwRK5PNr7m9OhymwblNFuzmAaLH7bWdzzKiOOA==}
+  '@polkadot/rpc-augment@13.2.1':
+    resolution: {integrity: sha512-HkndaAJPR1fi2xrzvP3q4g48WUCb26btGTeg1AKG9FGx9P2dgtpaPRmbMitmgVSzzRurrkxf3Meip8nC7BwDeg==}
     engines: {node: '>=18'}
 
   '@polkadot/rpc-augment@7.15.1':
@@ -1468,8 +1457,8 @@ packages:
     resolution: {integrity: sha512-yaveqxNcmyluyNgsBT5tpnCa/md0CGbOtRK7K82LWsz7gsbh0x80GBbJrQGxsUybg1gPeZbO1q9IigwA6fY8ag==}
     engines: {node: '>=18'}
 
-  '@polkadot/rpc-core@13.1.1':
-    resolution: {integrity: sha512-dxb1PFCzP9A8go/20KO+nNiqYMjsjY2gU/w0iPyLVH64yI9CW8GWd+77oEmcAuHKMPEHgpfa6sGuR/r0z+M5SQ==}
+  '@polkadot/rpc-core@13.2.1':
+    resolution: {integrity: sha512-hy0GksUlb/TfQ38m3ysIWj3qD+rIsyCdxx8Ug5rIx1u0odv86NZ7nTqtH066Ct2riVaPBgBkObFnlpDWTJ6auA==}
     engines: {node: '>=18'}
 
   '@polkadot/rpc-core@7.15.1':
@@ -1492,8 +1481,8 @@ packages:
     resolution: {integrity: sha512-cAhfN937INyxwW1AdjABySdCKhC7QCIONRDHDea1aLpiuxq/w+QwjxauR9fCNGh3lTaAwwnmZ5WfFU2PtkDMGQ==}
     engines: {node: '>=18'}
 
-  '@polkadot/rpc-provider@13.1.1':
-    resolution: {integrity: sha512-9tG8fEZWsxCoF6PKGECIQHp2tORKt6yIESSdg3pWSP/4xzBEQulqn0SKHcOZV/wwY8goSmw14dA0iyJdLFRP5g==}
+  '@polkadot/rpc-provider@13.2.1':
+    resolution: {integrity: sha512-bbMVYHTNFUa89aY3UQ1hFYD+dP+v+0vhjsnHYYlv37rSUTqOGqW91rkHd63xYCpLAimFt7KRw8xR+SMSYiuDjw==}
     engines: {node: '>=18'}
 
   '@polkadot/rpc-provider@7.15.1':
@@ -1516,8 +1505,8 @@ packages:
     resolution: {integrity: sha512-3fDCOy2BEMuAtMYl4crKg76bv/0pDNEuzpAzV4EBUMIlJwypmjy5sg3gUPCMcA+ckX3xb8DhkWU4ceUdS7T2KQ==}
     engines: {node: '>=18'}
 
-  '@polkadot/types-augment@13.1.1':
-    resolution: {integrity: sha512-ltsznxCNJR/RKMEbBgwAC9VgbJBYT08MltDiZKOnjJD+Uk2RnOkTpnV/rOCd6MxQ1TNQV/KBCvWT2Y0pK5Gw0Q==}
+  '@polkadot/types-augment@13.2.1':
+    resolution: {integrity: sha512-FpV7/2kIJmmswRmwUbp41lixdNX15olueUjHnSweFk0xEn2Ur43oC0Y3eU3Ab7Y5gPJpceMCfwYz+PjCUGedDA==}
     engines: {node: '>=18'}
 
   '@polkadot/types-augment@7.15.1':
@@ -1540,8 +1529,8 @@ packages:
     resolution: {integrity: sha512-DiPGRFWtVMepD9i05eC3orSbGtpN7un/pXOrXu0oriU+oxLkpvZH68ZsPNtJhKdQy03cAYtvB8elJOFJZYqoqQ==}
     engines: {node: '>=18'}
 
-  '@polkadot/types-codec@13.1.1':
-    resolution: {integrity: sha512-sSvtUtP7YxhlKjN0HIFWIlDUsAxQbJqnAGmFadx4FT6jjHpKSyxi1bBVI5fJqlYVereHkFWhPYX044DIjZnk7w==}
+  '@polkadot/types-codec@13.2.1':
+    resolution: {integrity: sha512-tFAzzS8sMYItoD5a91sFMD+rskWyv4WjSmUZaj0Y4OfLtDAiQvgO0KncdGJIB6D+zZ/T7khpgsv/CZbN3YnezA==}
     engines: {node: '>=18'}
 
   '@polkadot/types-codec@7.15.1':
@@ -1564,8 +1553,8 @@ packages:
     resolution: {integrity: sha512-nOpeAKZLdSqNMfzS3waQXgyPPaNt8rUHEmR5+WNv6c/Ke/vyf710wjxiTewfp0wpBgtdrimlgG4DLX1J9Ms1LA==}
     engines: {node: '>=18'}
 
-  '@polkadot/types-create@13.1.1':
-    resolution: {integrity: sha512-l3LBsMKtx6tYtqxY3IiBEfKtcRacyaKo9YWnh8QDtXlMwBgs+2KJj8sA8/y2OHOSiKYiffz8M/B7KHL7pF5s3Q==}
+  '@polkadot/types-create@13.2.1':
+    resolution: {integrity: sha512-O/WKdsrNuMaZLf+XRCdum2xJYs5OKC6N3EMPF5Uhg10b80Y/hQCbzA/iWd3/aMNDLUA5XWhixwzJdrZWIMVIzg==}
     engines: {node: '>=18'}
 
   '@polkadot/types-create@7.15.1':
@@ -1588,8 +1577,8 @@ packages:
     resolution: {integrity: sha512-bvhO4KQu/dgPmdwQXsweSMRiRisJ7Bp38lZVEIFykfd2qYyRW3OQEbIPKYpx9raD+fDATU0bTiKQnELrSGhYXw==}
     engines: {node: '>=18'}
 
-  '@polkadot/types-known@13.1.1':
-    resolution: {integrity: sha512-VY7WbcAhaadNarQXC8TaP+M262a+79091dAU1KYYTHxzCndC72ly0rSA+pZZ4bVloKdHrq6Xh3paAISSoEDXhg==}
+  '@polkadot/types-known@13.2.1':
+    resolution: {integrity: sha512-uz3c4/IvspLpgN8q15A+QH8KWFauzcrV3RfLFlMP2BkkF5qpOwNeP7c4U8j0CZGQySqBsJRCGWmgBXrXg669KA==}
     engines: {node: '>=18'}
 
   '@polkadot/types-known@4.17.1':
@@ -1620,8 +1609,8 @@ packages:
     resolution: {integrity: sha512-bz6JSt23UEZ2eXgN4ust6z5QF9pO5uNH7UzCP+8I/Nm85ZipeBYj2Wu6pLlE3Hw30hWZpuPxMDOKoEhN5bhLgw==}
     engines: {node: '>=18'}
 
-  '@polkadot/types-support@13.1.1':
-    resolution: {integrity: sha512-Xjj25175i4X39N37polUxZqtlloa5G5eizEbzk4qKvFdWuvPe6pOVS63oS7WzMhGbZi2PecThDFRz+GptcHqXQ==}
+  '@polkadot/types-support@13.2.1':
+    resolution: {integrity: sha512-jSbbUTXU+yZJQPRAWmxaDoe4NRO6SjpZPzBIbpuiadx1slON8XB80fVYIGBXuM2xRVrNrB6fCjyCTG7Razj6Hg==}
     engines: {node: '>=18'}
 
   '@polkadot/types-support@7.15.1':
@@ -1644,8 +1633,8 @@ packages:
     resolution: {integrity: sha512-ivYtt7hYcRvo69ULb1BJA9BE1uefijXcaR089Dzosr9+sMzvsB1yslNQReOq+Wzq6h6AQj4qex6qVqjWZE6Z4A==}
     engines: {node: '>=18'}
 
-  '@polkadot/types@13.1.1':
-    resolution: {integrity: sha512-ijNlMGgoUtPtjZCzBHqPJXd9PGwE+kKy7qzQ/Xav4RAMD8X/Mo+9okam755J9WNHCOcajVIQo0PDYeZzLYVk1Q==}
+  '@polkadot/types@13.2.1':
+    resolution: {integrity: sha512-5yQ0mHMNvwgXeHQ1RZOuHaeak3utAdcBqCpHoagnYrAnGHqtO7kg7YLtT4LkFw2nwL85axu8tOQMv6/3kpFy9w==}
     engines: {node: '>=18'}
 
   '@polkadot/types@4.17.1':
@@ -1690,12 +1679,6 @@ packages:
     peerDependencies:
       '@polkadot/util': 12.6.2
 
-  '@polkadot/util-crypto@13.0.2':
-    resolution: {integrity: sha512-woUsJJ6zd/caL7U+D30a5oM/+WK9iNI00Y8aNUHSj6Zq/KPzK9uqDBaLGWwlgrejoMQkxxiU2X0f2LzP15AtQg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': 13.0.2
-
   '@polkadot/util-crypto@13.1.1':
     resolution: {integrity: sha512-FG68rrLPdfLcscEyH10vnGkakM4O2lqr71S3GDhgc9WXaS8y9jisLgMPg8jbMHiQBJ3iKYkmtPKiLBowRslj2w==}
     engines: {node: '>=18'}
@@ -1720,10 +1703,6 @@ packages:
 
   '@polkadot/util@12.6.2':
     resolution: {integrity: sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==}
-    engines: {node: '>=18'}
-
-  '@polkadot/util@13.0.2':
-    resolution: {integrity: sha512-/6bS9sfhJLhs8QuqWaR1eRapzfDdGC5XAQZEPL9NN5sTTA7HxWos8rVleai0UERm8QUMabjZ9rK9KpzbXl7ojg==}
     engines: {node: '>=18'}
 
   '@polkadot/util@13.1.1':
@@ -1862,10 +1841,6 @@ packages:
     resolution: {integrity: sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==}
     engines: {node: '>=18'}
 
-  '@polkadot/x-bigint@13.0.2':
-    resolution: {integrity: sha512-h2jKT/UaxiEal8LhQeH6+GCjO7GwEqVAD2SNYteCOXff6yNttqAZYJuHZsndbVjVNwqRNf8D5q/zZkD0HUd6xQ==}
-    engines: {node: '>=18'}
-
   '@polkadot/x-bigint@13.1.1':
     resolution: {integrity: sha512-Cq4Y6fd9UWtRBZz8RX2tWEBL1IFwUtY6cL8p6HC9yhZtUR6OPjKZe6RIZQa9gSOoIuqZWd6PmtvSNGVH32yfkQ==}
     engines: {node: '>=18'}
@@ -1882,10 +1857,6 @@ packages:
     resolution: {integrity: sha512-8wM/Z9JJPWN1pzSpU7XxTI1ldj/AfC8hKioBlUahZ8gUiJaOF7K9XEFCrCDLis/A1BoOu7Ne6WMx/vsJJIbDWw==}
     engines: {node: '>=18'}
 
-  '@polkadot/x-fetch@13.0.2':
-    resolution: {integrity: sha512-B/gf9iriUr6za/Ui7zIFBfHz7UBZ68rJEIteWHx1UHRCZPcLqv+hgpev6xIGrkfFljI0/lI7IwtN2qy6HYzFBg==}
-    engines: {node: '>=18'}
-
   '@polkadot/x-fetch@13.1.1':
     resolution: {integrity: sha512-qA6mIUUebJbS+oWzq/EagZflmaoa9b25WvsxSFn7mCvzKngXzr+GYCY4XiDwKY/S+/pr/kvSCKZ1ia8BDqPBYQ==}
     engines: {node: '>=18'}
@@ -1900,10 +1871,6 @@ packages:
 
   '@polkadot/x-global@12.6.2':
     resolution: {integrity: sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==}
-    engines: {node: '>=18'}
-
-  '@polkadot/x-global@13.0.2':
-    resolution: {integrity: sha512-OoNIXLB5y8vIKpk4R+XmpDPhipNXWSUvEwUnpQT7NAxNLmzgMq1FhbrwBWWPRNHPrQonp7mqxV/X+v5lv1HW/g==}
     engines: {node: '>=18'}
 
   '@polkadot/x-global@13.1.1':
@@ -1927,13 +1894,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@polkadot/util': 12.6.2
-      '@polkadot/wasm-util': '*'
-
-  '@polkadot/x-randomvalues@13.0.2':
-    resolution: {integrity: sha512-SGj+L0H/7TWZtSmtkWlixO4DFzXDdluI0UscN2h285os2Ns8PnmBbue+iJ8PVSzpY1BOxd66gvkkpboPz+jXFQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': 13.0.2
       '@polkadot/wasm-util': '*'
 
   '@polkadot/x-randomvalues@13.1.1':
@@ -1963,10 +1923,6 @@ packages:
     resolution: {integrity: sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==}
     engines: {node: '>=18'}
 
-  '@polkadot/x-textdecoder@13.0.2':
-    resolution: {integrity: sha512-mauglOkTJxLGmLwLc3J5Jlq/W+SHP53eiy3F8/8JxxfnXrZKgWoQXGpvXYPjFnMZj0MzDSy/6GjyGWnDCgdQFA==}
-    engines: {node: '>=18'}
-
   '@polkadot/x-textdecoder@13.1.1':
     resolution: {integrity: sha512-LpZ9KYc6HdBH+i86bCmun4g4GWMiWN/1Pzs0hNdanlQMfqp3UGzl1Dqp0nozMvjWAlvyG7ip235VgNMd8HEbqg==}
     engines: {node: '>=18'}
@@ -1987,10 +1943,6 @@ packages:
     resolution: {integrity: sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==}
     engines: {node: '>=18'}
 
-  '@polkadot/x-textencoder@13.0.2':
-    resolution: {integrity: sha512-Lq08H2OnVXj97uaOwg7tcmRS7a4VJYkHEeWO4FyEMOk6P6lU6W8OVNjjxG0se9PCEgmyZPUDbJI//1ynzP4cXw==}
-    engines: {node: '>=18'}
-
   '@polkadot/x-textencoder@13.1.1':
     resolution: {integrity: sha512-w1mT15B9ptN5CJNgN/A0CmBqD5y9OePjBdU6gmAd8KRhwXCF0MTBKcEZk1dHhXiXtX+28ULJWLrfefC5gxy69Q==}
     engines: {node: '>=18'}
@@ -2009,10 +1961,6 @@ packages:
 
   '@polkadot/x-ws@12.6.2':
     resolution: {integrity: sha512-cGZWo7K5eRRQCRl2LrcyCYsrc3lRbTlixZh3AzgU8uX4wASVGRlNWi/Hf4TtHNe1ExCDmxabJzdIsABIfrr7xw==}
-    engines: {node: '>=18'}
-
-  '@polkadot/x-ws@13.0.2':
-    resolution: {integrity: sha512-nC5e2eY5D5ZR5teQOB7ib+dWLbmNws86cTz3BjKCalSMBBIn6i3V9ElgABpierBmnSJe9D94EyrH1BxdVfDxUg==}
     engines: {node: '>=18'}
 
   '@polkadot/x-ws@13.1.1':
@@ -2185,11 +2133,11 @@ packages:
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
 
-  '@snowbridge/api@0.1.19':
-    resolution: {integrity: sha512-bLvYJdgxl3cNMvyBM73M6CE0Quzjg9mgt2zEaW3iftft0RrV2jl/Urwfa9S+kPQjHLW/Jc/YVoLY89sPg2RaFg==}
+  '@snowbridge/api@0.1.20':
+    resolution: {integrity: sha512-InJe0dQkyN2Nfm5bhew1jemfds5Itf8fS9s2A/HKh58aBK0yk+KetLbZPI4+ntc/5AeShisAdcSySgxrSuRzgw==}
 
-  '@snowbridge/contract-types@0.1.19':
-    resolution: {integrity: sha512-eXLRkqD/6Ehicmkmnz76A5GQa34Kfdn2k9hjH2y64Q0A7y42uVFN7ACKOTYUhMXBbf9J9CI0sh2MFNpX1q/C7w==}
+  '@snowbridge/contract-types@0.1.20':
+    resolution: {integrity: sha512-DHxP3+puaIA9C6KTg79We7En9Abe+qFMYAdquvAL1P9laJuR1EJIr8Q8YEiBjoB74uh+MJhYWIlrEnnohXT6Dw==}
 
   '@snowfork/snowbridge-types@0.2.7':
     resolution: {integrity: sha512-Dz3OM8xvYhzL7XU/QOjgyPWZI4IgPKGByaJo6eZe3UMS6F7TLaFaZW1oYhQVTTahGWWAE6ZwwCuMkVh2FC/9bw==}
@@ -6932,9 +6880,9 @@ snapshots:
 
   '@darwinia/types@2.8.10': {}
 
-  '@digitalnative/type-definitions@1.1.27(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)':
+  '@digitalnative/type-definitions@1.1.27(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)':
     dependencies:
-      '@polkadot/keyring': 6.11.1(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      '@polkadot/keyring': 6.11.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       '@polkadot/types': 4.17.1
     transitivePeerDependencies:
       - '@polkadot/util'
@@ -7754,14 +7702,14 @@ snapshots:
     dependencies:
       '@open-web3/orml-type-definitions': 2.0.1
 
-  '@paraspell/sdk@6.0.0(@polkadot/api-base@11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/api@11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/apps-config@0.143.2(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@6.0.3))(@polkadot/types@11.3.1)(@polkadot/util@12.6.2)(bufferutil@4.0.8)(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@6.0.3)':
+  '@paraspell/sdk@6.1.1(@polkadot/api-base@11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/api@11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/apps-config@0.143.2(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@6.0.3))(@polkadot/types@11.3.1)(@polkadot/util@12.6.2)(bufferutil@4.0.8)(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@6.0.3)':
     dependencies:
       '@polkadot/api': 11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/api-base': 11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/apps-config': 0.143.2(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(utf-8-validate@6.0.3)
       '@polkadot/types': 11.3.1
       '@polkadot/util': 12.6.2
-      '@snowbridge/api': 0.1.19(bufferutil@4.0.8)(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@6.0.3)
+      '@snowbridge/api': 0.1.20(bufferutil@4.0.8)(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@6.0.3)
       ethers: 6.13.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
@@ -7924,20 +7872,20 @@ snapshots:
       '@polkadot/types': 12.4.2
       '@polkadot/types-augment': 12.4.2
       '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.0.2
+      '@polkadot/util': 13.1.1
       tslib: 2.7.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-augment@13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
+  '@polkadot/api-augment@13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@polkadot/api-base': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/rpc-augment': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/types': 13.1.1
-      '@polkadot/types-augment': 13.1.1
-      '@polkadot/types-codec': 13.1.1
+      '@polkadot/api-base': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/rpc-augment': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/types': 13.2.1
+      '@polkadot/types-augment': 13.2.1
+      '@polkadot/types-codec': 13.2.1
       '@polkadot/util': 13.1.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -8000,7 +7948,7 @@ snapshots:
     dependencies:
       '@polkadot/rpc-core': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/types': 12.4.2
-      '@polkadot/util': 13.0.2
+      '@polkadot/util': 13.1.1
       rxjs: 7.8.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -8008,10 +7956,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-base@13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
+  '@polkadot/api-base@13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@polkadot/rpc-core': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/types': 13.1.1
+      '@polkadot/rpc-core': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/types': 13.2.1
       '@polkadot/util': 13.1.1
       rxjs: 7.8.1
       tslib: 2.7.0
@@ -8101,8 +8049,8 @@ snapshots:
       '@polkadot/rpc-core': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       rxjs: 7.8.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -8110,14 +8058,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-derive@13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
+  '@polkadot/api-derive@13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@polkadot/api': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/api-augment': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/api-base': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/rpc-core': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/types': 13.1.1
-      '@polkadot/types-codec': 13.1.1
+      '@polkadot/api': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/api-augment': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/api-base': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/rpc-core': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/types': 13.2.1
+      '@polkadot/types-codec': 13.2.1
       '@polkadot/util': 13.1.1
       '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       rxjs: 7.8.1
@@ -8213,7 +8161,7 @@ snapshots:
       '@polkadot/api-augment': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/api-base': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/api-derive': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/keyring': 13.0.2(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      '@polkadot/keyring': 13.1.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       '@polkadot/rpc-augment': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/rpc-core': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/rpc-provider': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -8222,8 +8170,8 @@ snapshots:
       '@polkadot/types-codec': 12.4.2
       '@polkadot/types-create': 12.4.2
       '@polkadot/types-known': 12.4.2
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       eventemitter3: 5.0.1
       rxjs: 7.8.1
       tslib: 2.7.0
@@ -8232,20 +8180,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api@13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
+  '@polkadot/api@13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@polkadot/api-augment': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/api-base': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/api-derive': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/api-augment': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/api-base': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/api-derive': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/keyring': 13.1.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
-      '@polkadot/rpc-augment': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/rpc-core': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/rpc-provider': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/types': 13.1.1
-      '@polkadot/types-augment': 13.1.1
-      '@polkadot/types-codec': 13.1.1
-      '@polkadot/types-create': 13.1.1
-      '@polkadot/types-known': 13.1.1
+      '@polkadot/rpc-augment': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/rpc-core': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/rpc-provider': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/types': 13.2.1
+      '@polkadot/types-augment': 13.2.1
+      '@polkadot/types-codec': 13.2.1
+      '@polkadot/types-create': 13.2.1
+      '@polkadot/types-known': 13.2.1
       '@polkadot/util': 13.1.1
       '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       eventemitter3: 5.0.1
@@ -8310,7 +8258,7 @@ snapshots:
       '@crustio/type-definitions': 1.3.0
       '@darwinia/types': 2.8.10
       '@darwinia/types-known': 2.8.10
-      '@digitalnative/type-definitions': 1.1.27(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      '@digitalnative/type-definitions': 1.1.27(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       '@docknetwork/node-types': 0.16.0
       '@edgeware/node-types': 3.6.2-wako
       '@equilab/definitions': 1.4.18
@@ -8328,17 +8276,17 @@ snapshots:
       '@phala/typedefs': 0.2.33
       '@polkadot/api': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/api-derive': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/networks': 13.0.2
-      '@polkadot/react-identicon': 3.9.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/networks@13.0.2)(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@polkadot/networks': 13.1.1
+      '@polkadot/react-identicon': 3.9.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/networks@13.1.1)(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
-      '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/x-fetch': 13.0.2
-      '@polkadot/x-ws': 13.0.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
+      '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.1.1)
+      '@polkadot/x-fetch': 13.1.1
+      '@polkadot/x-ws': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polymeshassociation/polymesh-types': 5.7.0
-      '@snowfork/snowbridge-types': 0.2.7(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      '@snowfork/snowbridge-types': 0.2.7(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       '@sora-substrate/type-definitions': 1.27.7
       '@subsocial/definitions': 0.8.14(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@unique-nft/opal-testnet-types': 1003.70.0(@polkadot/api@12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@polkadot/types@12.4.2)
@@ -8348,7 +8296,7 @@ snapshots:
       '@zeitgeistpm/type-defs': 1.0.0
       '@zeroio/type-definitions': 0.0.14
       moonbeam-types-bundle: 2.0.10(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      pontem-types-bundle: 1.0.15(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      pontem-types-bundle: 1.0.15(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       rxjs: 7.8.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -8425,12 +8373,6 @@ snapshots:
       '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
       tslib: 2.7.0
 
-  '@polkadot/keyring@13.0.2(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
-      tslib: 2.7.0
-
   '@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)':
     dependencies:
       '@polkadot/util': 12.6.2
@@ -8443,23 +8385,23 @@ snapshots:
       '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       tslib: 2.7.0
 
-  '@polkadot/keyring@6.11.1(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)':
+  '@polkadot/keyring@6.11.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
 
-  '@polkadot/keyring@7.9.2(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)':
+  '@polkadot/keyring@7.9.2(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
 
-  '@polkadot/keyring@8.7.1(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)':
+  '@polkadot/keyring@8.7.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)':
     dependencies:
       '@babel/runtime': 7.25.6
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
 
   '@polkadot/keyring@8.7.1(@polkadot/util-crypto@8.7.1(@polkadot/util@8.7.1))(@polkadot/util@8.7.1)':
     dependencies:
@@ -8487,12 +8429,6 @@ snapshots:
       '@substrate/ss58-registry': 1.50.0
       tslib: 2.7.0
 
-  '@polkadot/networks@13.0.2':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      '@substrate/ss58-registry': 1.50.0
-      tslib: 2.7.0
-
   '@polkadot/networks@13.1.1':
     dependencies:
       '@polkadot/util': 13.1.1
@@ -8509,13 +8445,13 @@ snapshots:
       '@polkadot/util': 8.7.1
       '@substrate/ss58-registry': 1.50.0
 
-  '@polkadot/react-identicon@3.9.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/networks@13.0.2)(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)':
+  '@polkadot/react-identicon@3.9.1(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/networks@13.1.1)(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)':
     dependencies:
       '@polkadot/keyring': 13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/ui-settings': 3.9.1(@polkadot/networks@13.0.2)(@polkadot/util@13.0.2)
-      '@polkadot/ui-shared': 3.9.1(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
+      '@polkadot/ui-settings': 3.9.1(@polkadot/networks@13.1.1)(@polkadot/util@13.1.1)
+      '@polkadot/ui-shared': 3.9.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       ethereum-blockies-base64: 1.0.2
       jdenticon: 3.2.0
       react: 18.3.1
@@ -8556,18 +8492,18 @@ snapshots:
       '@polkadot/rpc-core': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.0.2
+      '@polkadot/util': 13.1.1
       tslib: 2.7.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-augment@13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
+  '@polkadot/rpc-augment@13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@polkadot/rpc-core': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/types': 13.1.1
-      '@polkadot/types-codec': 13.1.1
+      '@polkadot/rpc-core': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/types': 13.2.1
+      '@polkadot/types-codec': 13.2.1
       '@polkadot/util': 13.1.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -8629,7 +8565,7 @@ snapshots:
       '@polkadot/rpc-augment': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/rpc-provider': 12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/types': 12.4.2
-      '@polkadot/util': 13.0.2
+      '@polkadot/util': 13.1.1
       rxjs: 7.8.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -8637,11 +8573,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-core@13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
+  '@polkadot/rpc-core@13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@polkadot/rpc-augment': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/rpc-provider': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@polkadot/types': 13.1.1
+      '@polkadot/rpc-augment': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/rpc-provider': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/types': 13.2.1
       '@polkadot/util': 13.1.1
       rxjs: 7.8.1
       tslib: 2.7.0
@@ -8719,14 +8655,14 @@ snapshots:
 
   '@polkadot/rpc-provider@12.4.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@polkadot/keyring': 13.0.2(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      '@polkadot/keyring': 13.1.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       '@polkadot/types': 12.4.2
       '@polkadot/types-support': 12.4.2
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
-      '@polkadot/x-fetch': 13.0.2
-      '@polkadot/x-global': 13.0.2
-      '@polkadot/x-ws': 13.0.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
+      '@polkadot/x-fetch': 13.1.1
+      '@polkadot/x-global': 13.1.1
+      '@polkadot/x-ws': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       eventemitter3: 5.0.1
       mock-socket: 9.3.1
       nock: 13.5.5
@@ -8738,11 +8674,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-provider@13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
+  '@polkadot/rpc-provider@13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
       '@polkadot/keyring': 13.1.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
-      '@polkadot/types': 13.1.1
-      '@polkadot/types-support': 13.1.1
+      '@polkadot/types': 13.2.1
+      '@polkadot/types-support': 13.2.1
       '@polkadot/util': 13.1.1
       '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       '@polkadot/x-fetch': 13.1.1
@@ -8817,13 +8753,13 @@ snapshots:
     dependencies:
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.0.2
+      '@polkadot/util': 13.1.1
       tslib: 2.7.0
 
-  '@polkadot/types-augment@13.1.1':
+  '@polkadot/types-augment@13.2.1':
     dependencies:
-      '@polkadot/types': 13.1.1
-      '@polkadot/types-codec': 13.1.1
+      '@polkadot/types': 13.2.1
+      '@polkadot/types-codec': 13.2.1
       '@polkadot/util': 13.1.1
       tslib: 2.7.0
 
@@ -8855,11 +8791,11 @@ snapshots:
 
   '@polkadot/types-codec@12.4.2':
     dependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/x-bigint': 13.0.2
+      '@polkadot/util': 13.1.1
+      '@polkadot/x-bigint': 13.1.1
       tslib: 2.7.0
 
-  '@polkadot/types-codec@13.1.1':
+  '@polkadot/types-codec@13.2.1':
     dependencies:
       '@polkadot/util': 13.1.1
       '@polkadot/x-bigint': 13.1.1
@@ -8891,12 +8827,12 @@ snapshots:
   '@polkadot/types-create@12.4.2':
     dependencies:
       '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.0.2
+      '@polkadot/util': 13.1.1
       tslib: 2.7.0
 
-  '@polkadot/types-create@13.1.1':
+  '@polkadot/types-create@13.2.1':
     dependencies:
-      '@polkadot/types-codec': 13.1.1
+      '@polkadot/types-codec': 13.2.1
       '@polkadot/util': 13.1.1
       tslib: 2.7.0
 
@@ -8932,19 +8868,19 @@ snapshots:
 
   '@polkadot/types-known@12.4.2':
     dependencies:
-      '@polkadot/networks': 13.0.2
+      '@polkadot/networks': 13.1.1
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
       '@polkadot/types-create': 12.4.2
-      '@polkadot/util': 13.0.2
+      '@polkadot/util': 13.1.1
       tslib: 2.7.0
 
-  '@polkadot/types-known@13.1.1':
+  '@polkadot/types-known@13.2.1':
     dependencies:
       '@polkadot/networks': 13.1.1
-      '@polkadot/types': 13.1.1
-      '@polkadot/types-codec': 13.1.1
-      '@polkadot/types-create': 13.1.1
+      '@polkadot/types': 13.2.1
+      '@polkadot/types-codec': 13.2.1
+      '@polkadot/types-create': 13.2.1
       '@polkadot/util': 13.1.1
       tslib: 2.7.0
 
@@ -8992,10 +8928,10 @@ snapshots:
 
   '@polkadot/types-support@12.4.2':
     dependencies:
-      '@polkadot/util': 13.0.2
+      '@polkadot/util': 13.1.1
       tslib: 2.7.0
 
-  '@polkadot/types-support@13.1.1':
+  '@polkadot/types-support@13.2.1':
     dependencies:
       '@polkadot/util': 13.1.1
       tslib: 2.7.0
@@ -9034,21 +8970,21 @@ snapshots:
 
   '@polkadot/types@12.4.2':
     dependencies:
-      '@polkadot/keyring': 13.0.2(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      '@polkadot/keyring': 13.1.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       '@polkadot/types-augment': 12.4.2
       '@polkadot/types-codec': 12.4.2
       '@polkadot/types-create': 12.4.2
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       rxjs: 7.8.1
       tslib: 2.7.0
 
-  '@polkadot/types@13.1.1':
+  '@polkadot/types@13.2.1':
     dependencies:
       '@polkadot/keyring': 13.1.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
-      '@polkadot/types-augment': 13.1.1
-      '@polkadot/types-codec': 13.1.1
-      '@polkadot/types-create': 13.1.1
+      '@polkadot/types-augment': 13.2.1
+      '@polkadot/types-codec': 13.2.1
+      '@polkadot/types-create': 13.2.1
       '@polkadot/util': 13.1.1
       '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       rxjs: 7.8.1
@@ -9092,18 +9028,18 @@ snapshots:
       '@polkadot/util-crypto': 10.4.2(@polkadot/util@10.4.2)
       rxjs: 7.8.1
 
-  '@polkadot/ui-settings@3.9.1(@polkadot/networks@13.0.2)(@polkadot/util@13.0.2)':
+  '@polkadot/ui-settings@3.9.1(@polkadot/networks@13.1.1)(@polkadot/util@13.1.1)':
     dependencies:
-      '@polkadot/networks': 13.0.2
-      '@polkadot/util': 13.0.2
+      '@polkadot/networks': 13.1.1
+      '@polkadot/util': 13.1.1
       eventemitter3: 5.0.1
       store: 2.0.12
       tslib: 2.7.0
 
-  '@polkadot/ui-shared@3.9.1(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)':
+  '@polkadot/ui-shared@3.9.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)':
     dependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/util-crypto': 13.0.2(@polkadot/util@13.0.2)
+      '@polkadot/util': 13.1.1
+      '@polkadot/util-crypto': 13.1.1(@polkadot/util@13.1.1)
       colord: 2.9.3
       tslib: 2.7.0
 
@@ -9131,19 +9067,6 @@ snapshots:
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@12.6.2)
       '@polkadot/x-bigint': 12.6.2
       '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
-      '@scure/base': 1.1.7
-      tslib: 2.7.0
-
-  '@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2)':
-    dependencies:
-      '@noble/curves': 1.5.0
-      '@noble/hashes': 1.5.0
-      '@polkadot/networks': 13.0.2
-      '@polkadot/util': 13.0.2
-      '@polkadot/wasm-crypto': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/x-bigint': 13.0.2
-      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       '@scure/base': 1.1.7
       tslib: 2.7.0
 
@@ -9213,16 +9136,6 @@ snapshots:
       bn.js: 5.2.1
       tslib: 2.7.0
 
-  '@polkadot/util@13.0.2':
-    dependencies:
-      '@polkadot/x-bigint': 13.0.2
-      '@polkadot/x-global': 13.0.2
-      '@polkadot/x-textdecoder': 13.0.2
-      '@polkadot/x-textencoder': 13.0.2
-      '@types/bn.js': 5.1.5
-      bn.js: 5.2.1
-      tslib: 2.7.0
-
   '@polkadot/util@13.1.1':
     dependencies:
       '@polkadot/x-bigint': 13.1.1
@@ -9267,13 +9180,6 @@ snapshots:
       '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.7.0
 
-  '@polkadot/wasm-bridge@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
-      tslib: 2.7.0
-
   '@polkadot/wasm-bridge@7.3.2(@polkadot/util@13.1.1)(@polkadot/x-randomvalues@13.1.1(@polkadot/util@13.1.1)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
     dependencies:
       '@polkadot/util': 13.1.1
@@ -9301,11 +9207,6 @@ snapshots:
       '@polkadot/util': 12.6.2
       tslib: 2.7.0
 
-  '@polkadot/wasm-crypto-asmjs@7.3.2(@polkadot/util@13.0.2)':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      tslib: 2.7.0
-
   '@polkadot/wasm-crypto-asmjs@7.3.2(@polkadot/util@13.1.1)':
     dependencies:
       '@polkadot/util': 13.1.1
@@ -9328,16 +9229,6 @@ snapshots:
       '@polkadot/wasm-crypto-wasm': 7.3.2(@polkadot/util@12.6.2)
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@12.6.2)
       '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
-      tslib: 2.7.0
-
-  '@polkadot/wasm-crypto-init@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/wasm-bridge': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-asmjs': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/wasm-crypto-wasm': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.7.0
 
   '@polkadot/wasm-crypto-init@7.3.2(@polkadot/util@13.1.1)(@polkadot/x-randomvalues@13.1.1(@polkadot/util@13.1.1)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
@@ -9370,12 +9261,6 @@ snapshots:
     dependencies:
       '@polkadot/util': 12.6.2
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@12.6.2)
-      tslib: 2.7.0
-
-  '@polkadot/wasm-crypto-wasm@7.3.2(@polkadot/util@13.0.2)':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
       tslib: 2.7.0
 
   '@polkadot/wasm-crypto-wasm@7.3.2(@polkadot/util@13.1.1)':
@@ -9422,17 +9307,6 @@ snapshots:
       '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
       tslib: 2.7.0
 
-  '@polkadot/wasm-crypto@7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/wasm-bridge': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-asmjs': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/wasm-crypto-init': 7.3.2(@polkadot/util@13.0.2)(@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-wasm': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/wasm-util': 7.3.2(@polkadot/util@13.0.2)
-      '@polkadot/x-randomvalues': 13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))
-      tslib: 2.7.0
-
   '@polkadot/wasm-crypto@7.3.2(@polkadot/util@13.1.1)(@polkadot/x-randomvalues@13.1.1(@polkadot/util@13.1.1)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2)))':
     dependencies:
       '@polkadot/util': 13.1.1
@@ -9454,11 +9328,6 @@ snapshots:
       '@polkadot/util': 12.6.2
       tslib: 2.7.0
 
-  '@polkadot/wasm-util@7.3.2(@polkadot/util@13.0.2)':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      tslib: 2.7.0
-
   '@polkadot/wasm-util@7.3.2(@polkadot/util@13.1.1)':
     dependencies:
       '@polkadot/util': 13.1.1
@@ -9472,11 +9341,6 @@ snapshots:
   '@polkadot/x-bigint@12.6.2':
     dependencies:
       '@polkadot/x-global': 12.6.2
-      tslib: 2.7.0
-
-  '@polkadot/x-bigint@13.0.2':
-    dependencies:
-      '@polkadot/x-global': 13.0.2
       tslib: 2.7.0
 
   '@polkadot/x-bigint@13.1.1':
@@ -9499,12 +9363,6 @@ snapshots:
   '@polkadot/x-fetch@12.6.2':
     dependencies:
       '@polkadot/x-global': 12.6.2
-      node-fetch: 3.3.2
-      tslib: 2.7.0
-
-  '@polkadot/x-fetch@13.0.2':
-    dependencies:
-      '@polkadot/x-global': 13.0.2
       node-fetch: 3.3.2
       tslib: 2.7.0
 
@@ -9531,10 +9389,6 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
-  '@polkadot/x-global@13.0.2':
-    dependencies:
-      tslib: 2.7.0
-
   '@polkadot/x-global@13.1.1':
     dependencies:
       tslib: 2.7.0
@@ -9557,13 +9411,6 @@ snapshots:
       '@polkadot/util': 12.6.2
       '@polkadot/wasm-util': 7.3.2(@polkadot/util@12.6.2)
       '@polkadot/x-global': 12.6.2
-      tslib: 2.7.0
-
-  '@polkadot/x-randomvalues@13.0.2(@polkadot/util@13.0.2)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))':
-    dependencies:
-      '@polkadot/util': 13.0.2
-      '@polkadot/wasm-util': 7.3.2(@polkadot/util@12.6.2)
-      '@polkadot/x-global': 13.0.2
       tslib: 2.7.0
 
   '@polkadot/x-randomvalues@13.1.1(@polkadot/util@13.1.1)(@polkadot/wasm-util@7.3.2(@polkadot/util@12.6.2))':
@@ -9598,11 +9445,6 @@ snapshots:
       '@polkadot/x-global': 12.6.2
       tslib: 2.7.0
 
-  '@polkadot/x-textdecoder@13.0.2':
-    dependencies:
-      '@polkadot/x-global': 13.0.2
-      tslib: 2.7.0
-
   '@polkadot/x-textdecoder@13.1.1':
     dependencies:
       '@polkadot/x-global': 13.1.1
@@ -9626,11 +9468,6 @@ snapshots:
   '@polkadot/x-textencoder@12.6.2':
     dependencies:
       '@polkadot/x-global': 12.6.2
-      tslib: 2.7.0
-
-  '@polkadot/x-textencoder@13.0.2':
-    dependencies:
-      '@polkadot/x-global': 13.0.2
       tslib: 2.7.0
 
   '@polkadot/x-textencoder@13.1.1':
@@ -9660,15 +9497,6 @@ snapshots:
   '@polkadot/x-ws@12.6.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
       '@polkadot/x-global': 12.6.2
-      tslib: 2.7.0
-      ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@polkadot/x-ws@13.0.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
-    dependencies:
-      '@polkadot/x-global': 13.0.2
       tslib: 2.7.0
       ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
@@ -9861,14 +9689,14 @@ snapshots:
 
   '@sinclair/typebox@0.25.24': {}
 
-  '@snowbridge/api@0.1.19(bufferutil@4.0.8)(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@6.0.3)':
+  '@snowbridge/api@0.1.20(bufferutil@4.0.8)(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@6.0.3)':
     dependencies:
       '@polkadot/api': 11.3.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
       '@polkadot/types': 11.3.1
       '@polkadot/util': 12.6.2
       '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
-      '@snowbridge/contract-types': 0.1.19(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@snowbridge/contract-types': 0.1.20(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@typechain/ethers-v6': 0.5.1(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@6.0.3))(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)
       ethers: 6.13.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       rxjs: 7.8.1
@@ -9879,17 +9707,17 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@snowbridge/contract-types@0.1.19(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
+  '@snowbridge/contract-types@0.1.20(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
       ethers: 6.13.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@snowfork/snowbridge-types@0.2.7(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)':
+  '@snowfork/snowbridge-types@0.2.7(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)':
     dependencies:
       '@polkadot/api': 7.15.1
-      '@polkadot/keyring': 8.7.1(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      '@polkadot/keyring': 8.7.1(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       '@polkadot/types': 7.15.1
     transitivePeerDependencies:
       - '@polkadot/util'
@@ -9905,7 +9733,7 @@ snapshots:
 
   '@subsocial/definitions@0.8.14(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@polkadot/api': 13.1.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@polkadot/api': 13.2.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       lodash.camelcase: 4.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -13606,9 +13434,9 @@ snapshots:
 
   pnglib@0.0.1: {}
 
-  pontem-types-bundle@1.0.15(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2):
+  pontem-types-bundle@1.0.15(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1):
     dependencies:
-      '@polkadot/keyring': 7.9.2(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
+      '@polkadot/keyring': 7.9.2(@polkadot/util-crypto@13.1.1(@polkadot/util@13.1.1))(@polkadot/util@13.1.1)
       '@polkadot/types': 6.12.1
       typescript: 4.9.5
     transitivePeerDependencies:


### PR DESCRIPTION
**Thank you for your contribution** to the [Lastic - Blockspace markeplace](https://lastic.xyz).

Following PR updates ParaSpell from v6.0.0 to v6.1.1. This version features some refactors for better code efficiency.
No breaking change for this project. Tested on localhost, all cross-chain cases work.

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

## Context

- [ ] Closes #<issue_number>

#### Did your issue had any of the "$" label on it?

- [ ] My BTC address:
